### PR TITLE
Output changed from hex to utf8

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ e.g. on Mac OS X: `secretkey | pbcopy` will put a secret key on your clipboard.
 ## Credits
 
 Credit is due to @thejh and @dimadima for their answers on http://stackoverflow.com/questions/8855687/secure-random-token-in-node-js
+
+As well as Šime Vidas and Deviljho for their answer on http://stackoverflow.com/questions/5963182/how-to-remove-spaces-from-a-string-using-javascript

--- a/bin/secretkey
+++ b/bin/secretkey
@@ -2,6 +2,8 @@
 // vi:syntax=javascript
 
 'use strict';
-require('crypto').randomBytes(48, function(ex, buf) { 
-  console.log(buf.toString('hex'));
+require('crypto').randomBytes(48, function(ex, buf) {
+  let output = buf.toString('utf8');
+  output = output.replace(/\s/g, '');
+  console.log(output);
 });


### PR DESCRIPTION
Hi Ivan,

I'm in the 401 JS at CodeFellows right now.

Tyler Morgan mentioned in class yesterday that he thinks ideally the output of secret key would be all available characters, not just hex, so I decided to try and make that happen.

My solution requires regex, which is generally slow, but for this application seems fine.

What are your thoughts? Is there a better way to restrict spaces from being outputted? 
